### PR TITLE
Add README and marketplace.json for plugin distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,39 @@
+{
+  "name": "diverta-kuroco-skills",
+  "owner": {
+    "name": "Diverta inc."
+  },
+  "metadata": {
+    "description": "Kuroco Headless CMS integration patterns, best practices, and development guidelines / Kuroco HeadlessCMSの統合パターン、ベストプラクティス、開発ガイドライン",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "kuroco-skills",
+      "source": ".",
+      "description": "Kuroco Headless CMS integration patterns, best practices, and development guidelines / Kuroco HeadlessCMSの統合パターン、ベストプラクティス、開発ガイドライン",
+      "version": "1.0.0",
+      "author": {
+        "name": "Diverta inc."
+      },
+      "keywords": [
+        "kuroco",
+        "headless-cms",
+        "api",
+        "nuxt",
+        "next",
+        "frontend",
+        "topics",
+        "member",
+        "authentication",
+        "batch",
+        "webhook",
+        "smarty",
+        "cms",
+        "rcms",
+        "diverta"
+      ],
+      "license": "MIT"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Kuroco Headless CMS integration patterns, best practices, and development guidelines / Kuroco HeadlessCMSの統合パターン、ベストプラクティス、開発ガイドライン",
   "author": {
-    "name": "Kenta Katoh"
+    "name": "Diverta inc."
   },
   "keywords": [
     "kuroco",


### PR DESCRIPTION
## Summary
- Add bilingual README (EN/JP) with installation instructions
- Add `marketplace.json` for Claude Code plugin marketplace support
- Update author to "Diverta inc." in plugin configuration

## Changes
- **README.md**: Installation guide, skill descriptions, and usage examples
- **.claude-plugin/marketplace.json**: Marketplace configuration with metadata and keywords
- **.claude-plugin/plugin.json**: Updated author field

## Test plan
- [ ] Verify plugin can be installed via `/plugin marketplace add diverta/kuroco-skills`
- [ ] Confirm skills appear correctly after installation
- [ ] Test each skill triggers with expected keywords

🤖 Generated with [Claude Code](https://claude.com/claude-code)