### PR TITLE
fix: Use object format for source field in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,10 @@
   "plugins": [
     {
       "name": "kuroco-skills",
-      "source": ".",
+      "source": {
+        "source": "github",
+        "repo": "diverta/kuroco-skills"
+      },
       "description": "Kuroco Headless CMS integration patterns, best practices, and development guidelines / Kuroco HeadlessCMSの統合パターン、ベストプラクティス、開発ガイドライン",
       "version": "1.0.0",
       "author": {


### PR DESCRIPTION
## Summary
- Fix marketplace.json source field format for Claude Code plugin marketplace compatibility

## Problem
The `/plugin marketplace add diverta/kuroco-skills` command was failing with:
```
Error: Invalid schema: plugins.0.source: Invalid input
```

## Solution
Changed `source` from string format to object format:

```diff
- "source": ".",
+ "source": {
+   "source": "github",
+   "repo": "diverta/kuroco-skills"
+ },
```

## Test plan
- [ ] Clear cache: `rm -rf ~/.claude/plugins/marketplaces/diverta-kuroco-skills`
- [ ] Run: `/plugin marketplace add diverta/kuroco-skills`
- [ ] Verify installation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)