### PR TITLE
fix: Download sync script from GitHub instead of local reference

### DIFF
--- a/skills/kuroco-docs/SKILL.md
+++ b/skills/kuroco-docs/SKILL.md
@@ -12,20 +12,20 @@ description: Kurocoドキュメントの検索・参照ガイド。使用キー�
 ### 1. docsフォルダの存在確認
 
 ```bash
-ls docs/
+ls ${CLAUDE_PLUGIN_ROOT}/docs/
 ```
 
 **docsフォルダが空または存在しない場合:**
 → ユーザーに「Kurocoドキュメントがまだ同期されていません。同期コマンドを実行してもよいですか？」と確認してから以下を実行：
 
 ```bash
-bash scripts/sync-docs.sh
+curl -fsSL https://raw.githubusercontent.com/diverta/kuroco-skills/main/skills/kuroco-docs/scripts/sync-docs.sh | bash -s -- "${CLAUDE_PLUGIN_ROOT}"
 ```
 
 ### 2. 同期日時の確認（1ヶ月チェック）
 
 ```bash
-cat docs/.last_sync
+cat ${CLAUDE_PLUGIN_ROOT}/docs/.last_sync
 ```
 
 このファイルには以下の形式で同期日時が記録されています：
@@ -35,7 +35,7 @@ cat docs/.last_sync
 **1ヶ月（30日 = 2592000秒）以上経過しているかチェック:**
 
 ```bash
-last_sync=$(head -1 docs/.last_sync)
+last_sync=$(head -1 ${CLAUDE_PLUGIN_ROOT}/docs/.last_sync)
 now=$(date +%s)
 diff=$((now - last_sync))
 if [ $diff -gt 2592000 ]; then echo "1ヶ月以上経過"; else echo "最新"; fi
@@ -47,7 +47,7 @@ if [ $diff -gt 2592000 ]; then echo "1ヶ月以上経過"; else echo "最新"; f
 ## ドキュメントの場所
 
 ```
-docs/
+${CLAUDE_PLUGIN_ROOT}/docs/
 ```
 
 ## ディレクトリ構造
@@ -68,7 +68,7 @@ docs/
 ### 方法1: INDEX.mdを最初に確認（推奨）
 
 ```bash
-cat docs/INDEX.md
+cat ${CLAUDE_PLUGIN_ROOT}/docs/INDEX.md
 ```
 
 INDEX.mdには以下が含まれています：
@@ -82,26 +82,26 @@ Claude CodeのGrepツールを使用してください（Bashのgrepより高速
 
 ```
 # キーワードで検索（ファイルパスのみ）
-Grep: pattern="エンドポイント" path="docs/"
+Grep: pattern="エンドポイント" path="${CLAUDE_PLUGIN_ROOT}/docs/"
 
 # 内容も確認したい場合
-Grep: pattern="エンドポイント" path="docs/" output_mode="content"
+Grep: pattern="エンドポイント" path="${CLAUDE_PLUGIN_ROOT}/docs/" output_mode="content"
 
 # 特定ディレクトリ内を検索
-Grep: pattern="ログイン" path="docs/tutorials/"
+Grep: pattern="ログイン" path="${CLAUDE_PLUGIN_ROOT}/docs/tutorials/"
 
 # 正規表現で検索
-Grep: pattern="filter.*query" path="docs/reference/"
+Grep: pattern="filter.*query" path="${CLAUDE_PLUGIN_ROOT}/docs/reference/"
 ```
 
 ### 方法3: Globツールでファイル検索
 
 ```
 # 全マークダウンファイル一覧
-Glob: pattern="**/*.md" path="docs/"
+Glob: pattern="**/*.md" path="${CLAUDE_PLUGIN_ROOT}/docs/"
 
 # tutorialsのファイル一覧
-Glob: pattern="*.md" path="docs/tutorials/"
+Glob: pattern="*.md" path="${CLAUDE_PLUGIN_ROOT}/docs/tutorials/"
 ```
 
 ## 目的別クイックリファレンス
@@ -167,7 +167,7 @@ Glob: pattern="*.md" path="docs/tutorials/"
 
 ```bash
 # 最新ドキュメントを同期
-bash scripts/sync-docs.sh
+curl -fsSL https://raw.githubusercontent.com/diverta/kuroco-skills/main/skills/kuroco-docs/scripts/sync-docs.sh | bash -s -- "${CLAUDE_PLUGIN_ROOT}"
 ```
 
 同期すると `docs/INDEX.md` も自動更新されます。

--- a/skills/kuroco-docs/scripts/sync-docs.sh
+++ b/skills/kuroco-docs/scripts/sync-docs.sh
@@ -6,7 +6,18 @@
 set -e
 
 ZIP_URL="https://rcms.g.kuroco-img.app/files/user/skills/current.zip"
-PLUGIN_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# PLUGIN_DIR can be passed as argument or environment variable
+# This allows the script to work when downloaded and executed remotely
+if [ -n "$1" ]; then
+  PLUGIN_DIR="$1"
+elif [ -n "$KUROCO_PLUGIN_DIR" ]; then
+  PLUGIN_DIR="$KUROCO_PLUGIN_DIR"
+else
+  # Default: derive from script location (for local execution)
+  PLUGIN_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+
 DOCS_DIR="$PLUGIN_DIR/docs"
 TEMP_DIR=$(mktemp -d)
 MAX_RETRIES=3


### PR DESCRIPTION
## Summary

- スキルインストール時に `scripts/` フォルダがコピーされない問題を修正
- `SKILL.md` が GitHub から直接 `sync-docs.sh` をダウンロードして実行するように変更
- `sync-docs.sh` がコマンドライン引数または環境変数で `PLUGIN_DIR` を受け取れるように修正

## Changes

- **SKILL.md**: 全ての相対パスを `${CLAUDE_PLUGIN_ROOT}` に変更、同期コマンドを curl でダウンロード実行する形式に変更
- **sync-docs.sh**: `PLUGIN_DIR` を `$1`（引数）、`$KUROCO_PLUGIN_DIR`（環境変数）、スクリプト位置からの導出の順で取得

## Test plan

- [ ] スキルを再インストールして同期コマンドが動作することを確認
- [ ] `${CLAUDE_PLUGIN_ROOT}/docs/` にドキュメントが同期されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)